### PR TITLE
fix: handle when both AWS_PROFILE and key pairs are set

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -2,6 +2,8 @@
 # Source this file or add these to your shell profile for testing
 
 # AWS Configuration for local testing
+# We set AWS_PROFILE for testing. The CLI tool should handle unsetting and resetting it.
+export AWS_PROFILE=default
 export AWS_ACCESS_KEY_ID=dummyaccess
 export AWS_SECRET_ACCESS_KEY=dummysecret
 export AWS_REGION=us-east-1

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -59,7 +59,7 @@ program
   .option("-p, --profile <profile>", "AWS profile")
   .option(
     "-d, --dynamodb-endpoint <endpoint>",
-    "Custom endpoint URL for DynamoDB"
+    "Custom endpoint URL for DynamoDB",
   )
   .option("-e, --kms-endpoint <endpoint>", "Custom KMS endpoint URL");
 
@@ -98,7 +98,7 @@ program
       } catch (error) {
         console.error(
           "Error listing secrets:",
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
         throw error;
       }
@@ -136,7 +136,7 @@ program
       } catch (error) {
         console.error(
           "Error storing secret:",
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
         throw error;
       }
@@ -179,7 +179,7 @@ program
       } catch (error) {
         console.error(
           "Error retrieving secret:",
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
         throw error;
       }
@@ -212,7 +212,7 @@ program
       } catch (error) {
         console.error(
           "Error deleting secret:",
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
         throw error;
       }
@@ -231,7 +231,7 @@ program
       } catch (error) {
         console.error(
           "Error setting up table:",
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
         throw error;
       }


### PR DESCRIPTION
The AWS sdk complains when you have both AWS_PROFILE and AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY set. For the CLI only, this checks is they are all set and if they are it "caches" AWS_PROFILE and unsets it so that the sdk won't complain. It will re-set it in the env after complete.